### PR TITLE
Add target for VSTS and TFS on prem

### DIFF
--- a/extension-manifest.json
+++ b/extension-manifest.json
@@ -4,6 +4,7 @@
     "name": "DLM Automation Build",
     "version": "1.0.16",
     "publisher": "redgatesoftware",
+    "targets": [{"id": "Microsoft.VisualStudio.Services"}],
     "description": "Build, test, sync and publish databases with DLM Automation.",
     "public": true,
     "icons": {


### PR DESCRIPTION
This adds a target for hosted and on prem, this fixes the build warning saying it isn't set and uses a default.

This does not require a release it just fixes the build for future builds