### PR TITLE
Use this defined variable instead.

### DIFF
--- a/TheTask/SqlCiTask.ps1
+++ b/TheTask/SqlCiTask.ps1
@@ -145,7 +145,7 @@ Write-Debug "nugetPackageVersionUseBuildNumber = $nugetPackageVersionUseBuildNum
 
 
 # This will be empty if it's a Release.
-$buildSourcesDirectory = Get-TaskVariable -Context $distributedTaskContext -Name "Build.SourcesDirectory"
+$buildSourcesDirectory = $env:BUILD_SOURCESDIRECTORY
 
 # Build version number
 

--- a/extension-manifest.json
+++ b/extension-manifest.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "redgateSqlCi",
     "name": "DLM Automation Build",
-    "version": "1.0.16",
+    "version": "1.0.17",
     "publisher": "redgatesoftware",
     "targets": [{"id": "Microsoft.VisualStudio.Services"}],
     "description": "Build, test, sync and publish databases with DLM Automation.",


### PR DESCRIPTION
This might fix an issue where Get-TaskVariable can't be found for some reason (We already use this way of getting variables elsewhere in the script)